### PR TITLE
fixing 'Parsing message body failed: Invalid JSON'

### DIFF
--- a/ZAP-scripts/14-5-1-HTTP-methods.py
+++ b/ZAP-scripts/14-5-1-HTTP-methods.py
@@ -39,7 +39,9 @@ def scanNode(sas, msg):
 
     code = str(msg.getResponseHeader().getStatusCode())
     if (re.search(pattern,code)):
-      body = msg.getResponseBody().toString()
+      #set response and request body to empy JSON so it can be parsed correctly
+      msg.setResponseBody("{}") 
+      msg.setRequestBody("{}")
       sas.raiseAlert(alertRisk, alertReliability, alertTitle, alertDescription, 
         msg.getRequestHeader().getURI().toString(), 
         i, "", alertInfo, alertSolution[0], "", cweID, wascID, msg);
@@ -47,5 +49,4 @@ def scanNode(sas, msg):
 
 def scan(sas, msg, param, value):
   pass
-
 


### PR DESCRIPTION
When running this script on juice shop the following error populated the console:

Parsing message body failed: Invalid JSON: <json>:1:0 Expected json literal but found eof

It seemed when the raiseAlert method was called, the response body and request bodies were invalid JSON literals (this is probably a result of sending HTTP methods the application was not expecting). Since the alert does not include the message bodies, I set both to an empty JSON literal as a work around because we are only concerned about the successful response codes.